### PR TITLE
OpenShift integration tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 *.ipr
 greeting-service/target/
 name-service/target/
-
+tests/target

--- a/greeting-service/pom.xml
+++ b/greeting-service/pom.xml
@@ -18,7 +18,7 @@
     <version>1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>springboot-circuit-breaker-greeting</artifactId>
+  <artifactId>springboot-cb-greeting</artifactId>
 
   <name>Spring Boot - C/B Booster - Greeting Service</name>
 
@@ -44,6 +44,25 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <classifier>exec</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/greeting-service/src/main/java/io/openshift/booster/service/GreetingController.java
+++ b/greeting-service/src/main/java/io/openshift/booster/service/GreetingController.java
@@ -44,7 +44,7 @@ public class GreetingController {
      */
     @RequestMapping("/api/greeting")
     public Greeting getGreeting() throws Exception {
-        String result = String.format("Hello from %s!", this.nameService.getName());
+        String result = String.format("Hello, %s!", this.nameService.getName());
         handler.sendMessage();
         return new Greeting(result);
     }

--- a/greeting-service/src/main/java/io/openshift/booster/service/NameService.java
+++ b/greeting-service/src/main/java/io/openshift/booster/service/NameService.java
@@ -30,7 +30,7 @@ public class NameService {
 
     static final HystrixCommandKey KEY = HystrixCommandKey.Factory.asKey("NameService");
 
-    private final String nameHost = System.getProperty("name.host", "http://springboot-circuit-breaker-name");
+    private final String nameHost = System.getProperty("name.host", "http://springboot-cb-name");
     private final RestTemplate restTemplate = new RestTemplate();
 
     @HystrixCommand(commandKey = "NameService", fallbackMethod = "getFallbackName", commandProperties = {

--- a/greeting-service/src/main/resources/application.yml
+++ b/greeting-service/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+hystrix:
+  command:
+    default:
+      circuitBreaker:
+        requestVolumeThreshold: 3
+      metrics:
+        healthSnapshot:
+          intervalInMilliseconds: 100

--- a/name-service/pom.xml
+++ b/name-service/pom.xml
@@ -18,7 +18,7 @@
     <version>1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>springboot-circuit-breaker-name</artifactId>
+  <artifactId>springboot-cb-name</artifactId>
 
   <name>Spring Boot - C/B Booster - Name Service</name>
 
@@ -49,6 +49,25 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <classifier>exec</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/name-service/src/main/java/io/openshift/booster/service/NameController.java
+++ b/name-service/src/main/java/io/openshift/booster/service/NameController.java
@@ -50,7 +50,7 @@ public class NameController {
 
     private static final Logger LOG = LoggerFactory.getLogger(NameController.class);
 
-    private static final String theName = System.getenv("HOSTNAME") != null ? System.getenv("HOSTNAME") : "World";
+    private static final String theName = "World";
 
     private final AtomicBoolean doFail = new AtomicBoolean();
     private final NameServiceWebSockerHandler handler = new NameServiceWebSockerHandler();

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
       <groupId>io.openshift</groupId>
       <artifactId>booster-parent</artifactId>
-      <version>4</version>
+      <version>5</version>
     </parent>
 
     <groupId>io.openshift.booster</groupId>
@@ -34,11 +34,13 @@
     <properties>
         <springboot.version>1.4.1.RELEASE</springboot.version>
         <junit.version>4.12</junit.version>
+        <org.glassfish.javax.json>1.0.3</org.glassfish.javax.json>
     </properties>
 
     <modules>
         <module>greeting-service</module>
         <module>name-service</module>
+        <module>tests</module>
     </modules>
 
     <build>
@@ -67,6 +69,13 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.json</artifactId>
+                <version>${org.glassfish.javax.json}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.openshift.booster</groupId>
+        <artifactId>springboot-circuit-breaker-parent</artifactId>
+        <version>1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>springboot-circuit-breaker-tests</artifactId>
+
+    <name>Spring Boot - C/B Booster - Tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openshift.booster</groupId>
+            <artifactId>springboot-circuit-breaker-name</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.openshift.booster</groupId>
+            <artifactId>springboot-circuit-breaker-greeting</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>openshift-it</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <nameServiceTemplate>${project.parent.basedir}/name-service/target/classes/META-INF/fabric8/openshift.yml</nameServiceTemplate>
+                                <greetingServiceTemplate>${project.parent.basedir}/greeting-service/target/classes/META-INF/fabric8/openshift.yml</greetingServiceTemplate>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/tests/src/test/java/io/openshift/booster/OpenShiftIT.java
+++ b/tests/src/test/java/io/openshift/booster/OpenShiftIT.java
@@ -1,0 +1,166 @@
+package io.openshift.booster;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.response.Response;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.api.model.Route;
+import io.openshift.booster.test.OpenShiftTestAssistant;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.json.Json;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.jayway.awaitility.Awaitility.await;
+import static com.jayway.restassured.RestAssured.get;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/**
+ * @author Radek Koubsky
+ */
+public class OpenShiftIT {
+    private static final String NAME_SERVICE_APP = "springboot-cb-name";
+    private static final String GREETING_SERVICE_APP = "springboot-cb-greeting";
+
+    private static final String OK = "ok";
+    private static final String FAIL = "fail";
+    private static final String CLOSED = "closed";
+    private static final String OPEN = "open";
+    private static final String HELLO_OK = "Hello, World!";
+    private static final String HELLO_FALLBACK = "Hello, Fallback!";
+
+    // See also circuitBreaker.sleepWindowInMilliseconds
+    private static final long SLEEP_WINDOW = 5000l;
+    // See also circuitBreaker.requestVolumeThreshold
+    private static final long REQUEST_THRESHOLD = 3;
+
+    private static final OpenShiftTestAssistant OPENSHIFT = new OpenShiftTestAssistant();
+
+    private static String nameBaseUri;
+    private static String greetingBaseUri;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+
+        nameBaseUri = deployApp(NAME_SERVICE_APP, System.getProperty("nameServiceTemplate"));
+        greetingBaseUri = deployApp(GREETING_SERVICE_APP, System.getProperty("greetingServiceTemplate"));
+
+        await().atMost(5, TimeUnit.MINUTES).until(() -> {
+            List<Pod> list = OPENSHIFT.client().pods().inNamespace(OPENSHIFT.project()).list().getItems();
+            return list.stream()
+                    .filter(pod -> pod.getMetadata().getName().startsWith(NAME_SERVICE_APP) || pod.getMetadata().getName().startsWith(GREETING_SERVICE_APP))
+                    .filter(pod -> "running".equalsIgnoreCase(pod.getStatus().getPhase())).collect(Collectors.toList()).size() >= 2;
+        });
+
+        System.out.println("Pods running, waiting for probes...");
+        String greetingProbeUri = greetingBaseUri + "/api/greeting";
+        String nameProbeUri = nameBaseUri + "/api/info";
+
+        await().pollInterval(1, TimeUnit.SECONDS).atMost(5, TimeUnit.MINUTES).until(() -> {
+            try {
+                Response response = get(greetingProbeUri);
+                if (response.getStatusCode() == 200) {
+                    response = get(nameProbeUri);
+                    if (response.getStatusCode() == 200) {
+                        return true;
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+            return false;
+        });
+
+    }
+
+    @AfterClass
+    public static void teardown() throws Exception {
+        OPENSHIFT.cleanup();
+    }
+
+    @Test
+    public void testCircuitBreaker() throws InterruptedException {
+        assertCircuitBreaker(CLOSED);
+        assertGreeting(HELLO_OK);
+        changeNameServiceState(FAIL);
+        for (int i = 0; i < REQUEST_THRESHOLD; i++) {
+            assertGreeting(HELLO_FALLBACK);
+        }
+        // Circuit breaker should be open now
+        // Wait a little to get the current health counts - see also metrics.healthSnapshot.intervalInMilliseconds
+        await().atMost(5, TimeUnit.SECONDS).until(() -> testCircuitBreakerState(OPEN));
+        changeNameServiceState(OK);
+        // See also circuitBreaker.sleepWindowInMilliseconds
+        await().atMost(7, TimeUnit.SECONDS).pollDelay(SLEEP_WINDOW, TimeUnit.MILLISECONDS).until(() -> testGreeting(HELLO_OK));
+        // The health counts should be reset
+        assertCircuitBreaker(CLOSED);
+    }
+
+    private Response greetingResponse() {
+        return RestAssured.when().get(greetingBaseUri + "/api/greeting");
+    }
+
+    private void assertGreeting(String expected) {
+        Response response = greetingResponse();
+        response.then().statusCode(200).body(containsString(expected));
+    }
+
+    private boolean testGreeting(String expected) {
+        Response response = greetingResponse();
+        response.then().statusCode(200);
+        return response.getBody().asString().contains(expected);
+    }
+
+    private Response circuitBreakerResponse() {
+        return RestAssured.when().get(greetingBaseUri + "/api/cb-state");
+    }
+
+    private void assertCircuitBreaker(String expectedState) {
+        Response response = circuitBreakerResponse();
+        response.then().statusCode(200).body("state", equalTo(expectedState));
+    }
+
+    private boolean testCircuitBreakerState(String expectedState) {
+        Response response = circuitBreakerResponse();
+        response.then().statusCode(200);
+        return response.getBody().asString().contains(expectedState);
+    }
+
+    private void changeNameServiceState(String state) {
+        Response response = RestAssured.given().header("Content-type", "application/json")
+                .body(Json.createObjectBuilder().add("state", state).build().toString()).put(nameBaseUri + "/api/state");
+        response.then().assertThat().statusCode(200).body("state", equalTo(state));
+    }
+
+    /**
+     *
+     * @param name
+     * @param templatePath
+     * @return the app route
+     * @throws IOException
+     */
+    private static String deployApp(String name, String templatePath) throws IOException {
+        String appName = "";
+        List<? extends HasMetadata> entities = OPENSHIFT.deploy(name, new File(templatePath));
+
+        Optional<String> first = entities.stream().filter(hm -> hm instanceof DeploymentConfig).map(hm -> (DeploymentConfig) hm)
+                .map(dc -> dc.getMetadata().getName()).findFirst();
+        if (first.isPresent()) {
+            appName = first.get();
+        } else {
+            throw new IllegalStateException("Application deployment config not found");
+        }
+        Route route = OPENSHIFT.client().routes().inNamespace(OPENSHIFT.project()).withName(appName).get();
+        assertThat(route).isNotNull();
+        return "http://" + route.getSpec().getHost();
+    }
+}

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml" />
+    <logger name="org.hibernate.validator" level="info" /> <!-- Validator prints a lot of debug messages during integration tests -->
+</configuration>


### PR DESCRIPTION
I updated booster-parent version to 5 and made small changes to align the booster with specification.

The artifactId changes are due to too long service names. FMP shortened `springboot-circuit-breaker-greeting` and `springboot-circuit-breaker-name` service name to `springboot-circuit-break`, thus there were two services with `springboot-circuit-break` name.

To run IT, use `mvn clean verify -Popenshift,openshift-it `from root dir.

@alesj Can you please take a look, thanks.