### PR TITLE
Clarify and simplify the integration tests setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <arquillian.version>1.4.0.Final</arquillian.version>
     <awaitility.version>3.1.0</awaitility.version>
+    <commons-logging.version>1.2</commons-logging.version>
     <javax.json.version>1.0.3</javax.json.version>
     <junit.version>4.12</junit.version>
     <openjdk18-openshift.version>1.3</openjdk18-openshift.version>
@@ -88,6 +89,11 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>${commons-logging.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -51,14 +51,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.openshift.booster</groupId>
-      <artifactId>spring-boot-circuit-breaker-name</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.openshift.booster</groupId>
-      <artifactId>spring-boot-circuit-breaker-greeting</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>1.7.25</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -100,38 +96,25 @@
               <skip>false</skip>
               <profile>aggregate</profile>
             </configuration>
-          </plugin>
-
-          <!-- needed to be able to run the tests in an ephemeral namespace -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-image-streams</id>
-                <phase>pre-integration-test</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>${project.build.directory}</outputDirectory>
-                  <resources>
-                    <resource>
-                      <directory>${project.parent.basedir}/name-service/target</directory>
-                      <includes>
-                        <include>*-is.yml</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>${project.parent.basedir}/greeting-service/target</directory>
-                      <includes>
-                        <include>*-is.yml</include>
-                      </includes>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-            </executions>
+            <!--
+               We add the dependencies to the two modules that need to be deployed for the tests
+               to run.
+               This is done in order to make FMP pick up the generated Openshift
+               resources file of each module and create an "uber" resources file containing
+               resources for both modules (which is what the aggregate profile above does)
+            -->
+            <dependencies>
+              <dependency>
+                <groupId>io.openshift.booster</groupId>
+                <artifactId>spring-boot-circuit-breaker-name</artifactId>
+                <version>${project.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>io.openshift.booster</groupId>
+                <artifactId>spring-boot-circuit-breaker-greeting</artifactId>
+                <version>${project.version}</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -50,11 +50,16 @@
       <artifactId>javax.json</artifactId>
       <scope>test</scope>
     </dependency>
+    <!--
+    We need this because Apache httpclient depends on it
+    but the import of the Spring Boot BOM excludes it
+    (which makes sense for regular Spring Boot applications since they use jcl-over-slf4j,
+    but doesn't make sense for test artifacts like this one)
+    -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.25</version>
-      <scope>test</scope>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
     </dependency>
   </dependencies>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -59,7 +59,6 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The integration tests themselves don't depend on the code of the modules
being tested.
They do however depend on those modules being deployed to Openshift.
In order for FMP to be able to deploy the modules, it needs to be able
to create an uber-resource Openshift file that contains the Openshift
definitions of both modules. That is done using the "aggregate" profile,
but assumes that FMP can find the resource file for each module on it's
classpath.
That is why the configuration has been changed to make the modules
dependencies of FMP instead of the tests themselves.