### PR TITLE
changed test waiting to greeting response

### DIFF
--- a/tests/src/test/java/io/openshift/booster/OpenShiftIT.java
+++ b/tests/src/test/java/io/openshift/booster/OpenShiftIT.java
@@ -48,9 +48,9 @@ public class OpenShiftIT {
     public void setup() {
         await().pollInterval(1, TimeUnit.SECONDS).atMost(5, TimeUnit.MINUTES).until(() -> {
             try {
-                Response gr = RestAssured.get(greetingBaseUri + "api/ping");
-                Response nr = RestAssured.get(nameBaseUri + "api/ping");
-                return gr.getStatusCode() == 200 && nr.getStatusCode() == 200;
+                Response response = greetingResponse();
+                Response circuitBreakerState = circuitBreakerResponse();
+                return response.asString().contains(HELLO_OK) && circuitBreakerState.asString().contains(CLOSED);
             } catch (Exception ignored) {
                 return false;
             }


### PR DESCRIPTION
Changed the waiting condition.
Waiting just for status 200_ok sometimes lead to situation where both services were online but circuit breaker was open, thus failing the test.